### PR TITLE
Removed 'as bulk' from sendmail - no longer supported.,

### DIFF
--- a/meeting/api.py
+++ b/meeting/api.py
@@ -14,8 +14,7 @@ def send_invitation_emails(meeting):
 			subject=meeting.title,
 			message=meeting.invitation_message,
 			reference_doctype=meeting.doctype,
-			reference_name=meeting.name,
-			as_bulk=True
+			reference_name=meeting.name
 		)
 
 		meeting.status = "Invitation Sent"


### PR DESCRIPTION
the as_bulk=True is no longer supported and causes an error.