### PR TITLE
unexpected argument ‘bulk’ during mail rectified

### DIFF
--- a/meeting/api.py
+++ b/meeting/api.py
@@ -14,8 +14,7 @@ def send_invitation_emails(meeting):
 			subject=meeting.title,
 			message=meeting.invitation_message,
 			reference_doctype=meeting.doctype,
-			reference_name=meeting.name,
-			as_bulk=True
+			reference_name=meeting.name
 		)
 
 		meeting.status = "Invitation Sent"


### PR DESCRIPTION
TypeError: sendmail() got an unexpected keyword argument ‘bulk’

Above error removed, as per https://discuss.erpnext.com/t/meeting-app-unexpected-keyword-argument-bulk/86714